### PR TITLE
Modify on Connection header

### DIFF
--- a/src/WioLTE.cpp
+++ b/src/WioLTE.cpp
@@ -1032,7 +1032,7 @@ int WioLTE::HttpGet(const char* url, char* data, int dataSize, long timeout)
 	WioLTEHttpHeader header;
 	header["Accept"] = "*/*";
 	header["User-Agent"] = HTTP_USER_AGENT;
-	header["Connection"] = "Keep-Alive";
+	header["Connection"] = "close";
 
 	return HttpGet(url, data, dataSize, header, timeout);
 }
@@ -1122,7 +1122,7 @@ bool WioLTE::HttpPost(const char* url, const char* data, int* responseCode, long
 	WioLTEHttpHeader header;
 	header["Accept"] = "*/*";
 	header["User-Agent"] = HTTP_USER_AGENT;
-	header["Connection"] = "Keep-Alive";
+	header["Connection"] = "close";
 	header["Content-Type"] = HTTP_CONTENT_TYPE;
 
 	return HttpPost(url, data, responseCode, header, timeout);


### PR DESCRIPTION
`keep-alive` in `Connection` header is a header that is generally aimed at improving the speed and efficiency of a browser that downloads multiple files in parallel.
The server is opening the socket, there is a problem that it is not possible to proceed to the next process.
This fix has been made to specify that the socket is closed from the server side by specifying close (this is the standard behavior of HTTP 1.0).
- ref: https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Connection
- This problem hit to latest firmware(EC21JFAR06A02M4G) of EC21-J.