### PR TITLE
Check the response error code for `+QNTP` AT command, on `SyncTime()`

### DIFF
--- a/src/WioLTE.cpp
+++ b/src/WioLTE.cpp
@@ -933,9 +933,11 @@ bool WioLTE::Deactivate()
 bool WioLTE::SyncTime(const char* host)
 {
 	StringBuilder str;
+	std::string response;
 	if (!str.WriteFormat("AT+QNTP=1,\"%s\"", host)) return RET_ERR(false, E_UNKNOWN);
 	if (!_AtSerial.WriteCommandAndReadResponse(str.GetString(), "^OK$", 500, NULL)) return RET_ERR(false, E_UNKNOWN);
-	if (!_AtSerial.ReadResponse("^\\+QNTP: (.*)$", 125000, NULL)) return RET_ERR(false, E_UNKNOWN);
+	if (!_AtSerial.ReadResponse("^\\+QNTP: (.*)$", 125000, &response)) return RET_ERR(false, E_UNKNOWN);
+	if (strncmp(response.c_str(), "0,", 2) != 0) return RET_ERR(-1, E_UNKNOWN); // check whether the command finished successfully
 
 	return RET_OK(true);
 }


### PR DESCRIPTION
Prior to this commit, the response of `AT+QNTP=1` AT command hasn't been checked. This means the `SyncTime()` function won't return a falsy value even if the command execution was failed (e.g. because of `Open PDP context failed`).
This commit fixes that issue according to the `Rev. EC2x&EG9x&EM05_TCP/IP_AT_Commands_Manual_V1.0` document from QUECTEL.

The response payload format is `+QNTP: <err>,<time>`, and if the `err` code isn't `0`, that has to be an error indication; for more information, please refer to the `4 Summary of Error Codes` section.

So this commit makes the logic check the response error code is `0` or not.